### PR TITLE
chore: promote develop → release (branch standardization)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
     json5 "^2.1.2"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -38,7 +38,7 @@
   dependencies:
     "@babel/types" "^7.10.3"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     source-map "^0.5.0"
 
 "@babel/helper-function-name@^7.10.3":
@@ -82,7 +82,7 @@
     "@babel/helper-split-export-declaration" "^7.10.1"
     "@babel/template" "^7.10.1"
     "@babel/types" "^7.10.1"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.1":
   version "7.10.3"
@@ -248,7 +248,7 @@
     "@babel/types" "^7.10.3"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
+    lodash "4.17.19"
 
 "@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.10.3"
@@ -256,7 +256,7 @@
   integrity sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.3"
-    lodash "^4.17.13"
+    lodash "4.17.19"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":


### PR DESCRIPTION
## Summary
- Promote develop into release lane (branch standardization)
- Legacy repo brought into `develop → release → master` flow

## Triad Verdict
Triad executada — Verdict: PASS (legacy code, no new features)

## Risks
- Legacy dependencies may have security vulnerabilities (dependabot alerts pending)
- No CI/CD configured yet for this repo

## Rollback
- Revert the merge commit on release branch
- No production impact (legacy/archive repo)